### PR TITLE
Add mir_genre coar resource type mapping

### DIFF
--- a/src/main/resources/mycore-classifications/mir_genres.xml
+++ b/src/main/resources/mycore-classifications/mir_genres.xml
@@ -6,14 +6,14 @@
   <categories>
     <category ID="article">
       <label xml:lang="it" text="Articolo / Saggio" />
-      <label xml:lang="x-mapping" text="marcgt:article diniPublType:article diniPublType2022:Article schemaOrg:ScholarlyArticle" />
+      <label xml:lang="x-mapping" text="marcgt:article diniPublType:article diniPublType2022:Article schemaOrg:ScholarlyArticle coarResourceTypes32:c_6501" />
       <label xml:lang="en" text="Article / Chapter" />
       <label xml:lang="de" text="Artikel / Aufsatz" />
       <label xml:lang="x-hosts" text="journal newspaper collection festschrift proceedings standalone" />
       <category ID="chapter">
         <label xml:lang="en" text="Book chapter" />
         <label xml:lang="de" text="Buchkapitel" />
-        <label xml:lang="x-mapping" text="marcgt:article diniPublType:bookPart diniPublType2022:BookPart schemaOrg:Chapter" />
+        <label xml:lang="x-mapping" text="marcgt:article diniPublType:bookPart diniPublType2022:BookPart schemaOrg:Chapter coarResourceTypes32:c_3248" />
         <label xml:lang="x-hosts" text="book collection" />
         <label xml:lang="it" text="Capitolo di libro" />
       </category>
@@ -22,31 +22,32 @@
         <label xml:lang="x-hosts" text="lexicon" />
         <label xml:lang="it" text="Entrata Lessicale" />
         <label xml:lang="de" text="Lexikoneintrag" />
-        <label xml:lang="x-mapping" text="marcgt:article diniPublType:bookPart diniPublType2022:BookPart schemaOrg:Article" />
+        <label xml:lang="x-mapping" text="marcgt:article diniPublType:bookPart diniPublType2022:BookPart schemaOrg:Article coarResourceTypes32:c_3248 " />
       </category>
       <category ID="preface">
         <label xml:lang="de" text="Vorwort / Nachwort" />
         <label xml:lang="x-hosts" text="journal collection festschrift proceedings lexicon" />
-        <label xml:lang="x-mapping" text="marcgt:article diniPublType:bookPart diniPublType2022:BookPart schemaOrg:Chapter" />
+        <label xml:lang="x-mapping" text="marcgt:article diniPublType:bookPart diniPublType2022:BookPart schemaOrg:Chapter coarResourceTypes32:c_3248" />
         <label xml:lang="it" text="Prefazione / Epilogo" />
         <label xml:lang="en" text="Preface (foreword) / Postface" />
       </category>
       <category ID="speech">
         <label xml:lang="en" text="Lecture / Speech" />
         <label xml:lang="it" text="Conferenza" />
-        <label xml:lang="x-mapping" text="marcgt:article diniPublType:other diniPublType2022:Other schemaOrg:Article" />
+        <!-- TODO -->
+        <label xml:lang="x-mapping" text="marcgt:article diniPublType:other diniPublType2022:Other schemaOrg:Article coarResourceTypes32:c_18cc" />
         <label xml:lang="de" text="Vortrag" />
         <label xml:lang="x-hosts" text="proceedings standalone" />
       </category>
       <category ID="review">
-        <label xml:lang="x-mapping" text="marcgt:article diniPublType:review diniPublType2022:Recension schemaOrg:Review" />
+        <label xml:lang="x-mapping" text="marcgt:article diniPublType:review diniPublType2022:Recension schemaOrg:Review coarResourceTypes32:c_efa0" />
         <label xml:lang="it" text="Recensione" />
         <label xml:lang="de" text="Rezension" />
         <label xml:lang="en" text="Review" />
         <label xml:lang="x-hosts" text="journal newspaper collection festschrift proceedings standalone" />
       </category>
       <category ID="blog_entry">
-        <label xml:lang="x-mapping" text="marcgt:article diniPublType:article diniPublType2022:PartOfADynamicWebRessource schemaOrg:BlogPosting" />
+        <label xml:lang="x-mapping" text="marcgt:article diniPublType:article diniPublType2022:PartOfADynamicWebRessource schemaOrg:BlogPosting coarResourceTypes32:c_6947" />
         <label xml:lang="x-hosts" text="blog" />
         <label xml:lang="en" text="Blog entry" />
         <label xml:lang="de" text="Blog-Eintrag" />
@@ -58,10 +59,10 @@
       <label xml:lang="de" text="Hochschulschriften" />
       <label xml:lang="x-group" text="true" />
       <label xml:lang="x-hosts" text="series standalone" />
-      <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:workingPaper schemaOrg:Thesis XMetaDissPlusThesisLevel:other" />
+      <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:workingPaper schemaOrg:Thesis XMetaDissPlusThesisLevel:other coarResourceTypes32:c_46ec" />
       <label xml:lang="it" text="Tesi universitaria" />
       <category ID="exam">
-        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:masterThesis diniPublType2022:MasterThesis schemaOrg:Thesis XMetaDissPlusThesisLevel:Staatsexamen" />
+        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:masterThesis diniPublType2022:MasterThesis schemaOrg:Thesis XMetaDissPlusThesisLevel:Staatsexamen coarResourceTypes32:c_bdcc" />
         <label xml:lang="en" text="Exam" />
         <label xml:lang="it" text="Esame" />
         <label xml:lang="x-hosts" text="series standalone" />
@@ -70,20 +71,20 @@
       <category ID="dissertation">
         <label xml:lang="it" text="Tesi di Dottorato di ricerca" />
         <label xml:lang="de" text="Dissertation" />
-        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:doctoralThesis diniPublType2022:PhDThesis schemaOrg:Thesis XMetaDissPlusThesisLevel:thesis.doctoral" />
+        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:doctoralThesis diniPublType2022:PhDThesis schemaOrg:Thesis XMetaDissPlusThesisLevel:thesis.doctoral coarResourceTypes32:c_db06" />
         <label xml:lang="x-hosts" text="series standalone" />
         <label xml:lang="en" text="Dissertation" />
       </category>
       <category ID="habilitation">
         <label xml:lang="de" text="Habilitation" />
-        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:doctoralThesis diniPublType2022:Habilitation schemaOrg:Thesis XMetaDissPlusThesisLevel:thesis.habilitation" />
+        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:doctoralThesis diniPublType2022:Habilitation schemaOrg:Thesis XMetaDissPlusThesisLevel:thesis.habilitation coarResourceTypes32:c_db06" />
         <label xml:lang="x-hosts" text="series standalone" />
         <label xml:lang="it" text="Tesi di abilitazione alla libera docenza" />
         <label xml:lang="en" text="Habilitation" />
       </category>
       <category ID="diploma_thesis">
         <label xml:lang="it" text="Tesi di diploma" />
-        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:masterThesis diniPublType2022:MasterThesis schemaOrg:Thesis XMetaDissPlusThesisLevel:Diplom" />
+        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:masterThesis diniPublType2022:MasterThesis schemaOrg:Thesis XMetaDissPlusThesisLevel:Diplom coarResourceTypes32:c_bdcc" />
         <label xml:lang="en" text="Diploma thesis" />
         <label xml:lang="x-hosts" text="series standalone" />
         <label xml:lang="de" text="Diplomarbeit" />
@@ -93,11 +94,11 @@
         <label xml:lang="en" text="Master thesis" />
         <label xml:lang="de" text="Abschlussarbeit (Master)" />
         <label xml:lang="x-hosts" text="series standalone" />
-        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:masterThesis diniPublType2022:MasterThesis schemaOrg:Thesis XMetaDissPlusThesisLevel:master" />
+        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:masterThesis diniPublType2022:MasterThesis schemaOrg:Thesis XMetaDissPlusThesisLevel:master coarResourceTypes32:c_bdcc" />
       </category>
       <category ID="bachelor_thesis">
         <label xml:lang="it" text="Tesi di laurea triennale" />
-        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:bachelorThesis diniPublType2022:BachelorThesis schemaOrg:Thesis XMetaDissPlusThesisLevel:bachelor" />
+        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:bachelorThesis diniPublType2022:BachelorThesis schemaOrg:Thesis XMetaDissPlusThesisLevel:bachelor coarResourceTypes32:c_7a1f" />
         <label xml:lang="de" text="Abschlussarbeit (Bachelor)" />
         <label xml:lang="en" text="Bachelor thesis" />
         <label xml:lang="x-hosts" text="series standalone" />
@@ -105,13 +106,13 @@
       <category ID="student_resarch_project">
         <label xml:lang="it" text="Tesina" />
         <label xml:lang="en" text="Student research project" />
-        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:StudyThesis diniPublType2022:StudyThesis schemaOrg:Thesis XMetaDissPlusThesisLevel:other" />
+        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:StudyThesis diniPublType2022:StudyThesis schemaOrg:Thesis XMetaDissPlusThesisLevel:other coarResourceTypes32:c_46ec" />
         <label xml:lang="x-hosts" text="series standalone" />
         <label xml:lang="de" text="Studienarbeit" />
       </category>
       <category ID="magister_thesis">
         <label xml:lang="en" text="Magister thesis" />
-        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:masterThesis diniPublType2022:MasterThesis schemaOrg:Thesis XMetaDissPlusThesisLevel:M.A." />
+        <label xml:lang="x-mapping" text="marcgt:thesis diniPublType:masterThesis diniPublType2022:MasterThesis schemaOrg:Thesis XMetaDissPlusThesisLevel:M.A. coarResourceTypes32:c_bdcc" />
         <label xml:lang="de" text="Magisterarbeit" />
         <label xml:lang="it" text="Magisterarbeit" />
         <label xml:lang="x-hosts" text="series standalone" />
@@ -119,26 +120,26 @@
     </category>
     <category ID="collection">
       <label xml:lang="de" text="Sammelwerk" />
-      <label xml:lang="x-mapping" text="marcgt:series diniPublType:other diniPublType2022:EditedCollection schemaOrg:Book" />
+      <label xml:lang="x-mapping" text="marcgt:series diniPublType:other diniPublType2022:EditedCollection schemaOrg:Book coarResourceTypes32:c_2f33" />
       <label xml:lang="it" text="Compilazione" />
       <label xml:lang="x-hosts" text="series standalone" />
       <label xml:lang="en" text="Collection" />
       <category ID="festschrift">
         <label xml:lang="en" text="Festschrift" />
-        <label xml:lang="x-mapping" text="marcgt:festschrift diniPublType:report diniPublType2022:Report schemaOrg:Report" />
+        <label xml:lang="x-mapping" text="marcgt:festschrift diniPublType:report diniPublType2022:Report schemaOrg:Report coarResourceTypes32:QX5C-AR31" />
         <label xml:lang="x-hosts" text="series standalone" />
         <label xml:lang="de" text="Festschrift" />
         <label xml:lang="it" text="Commemorativo" />
       </category>
       <category ID="proceedings">
-        <label xml:lang="x-mapping" text="marcgt:conference_publication diniPublType:conferenceObject diniPublType2022:ConferenceProceedings schemaOrg:Book" />
+        <label xml:lang="x-mapping" text="marcgt:conference_publication diniPublType:conferenceObject diniPublType2022:ConferenceProceedings schemaOrg:Book coarResourceTypes32:c_f744" />
         <label xml:lang="en" text="Proceedings" />
         <label xml:lang="de" text="Tagungsband" />
         <label xml:lang="x-hosts" text="series standalone" />
         <label xml:lang="it" text="Procedimento" />
       </category>
       <category ID="lexicon">
-        <label xml:lang="x-mapping" text="marcgt:encyclopedia diniPublType:book diniPublType2022:Book schemaOrg:Book" />
+        <label xml:lang="x-mapping" text="marcgt:encyclopedia diniPublType:book diniPublType2022:Book schemaOrg:Book coarResourceTypes32:c_2f33" />
         <label xml:lang="x-hosts" text="series standalone" />
         <label xml:lang="it" text="Lessico" />
         <label xml:lang="de" text="Lexikon" />
@@ -150,23 +151,24 @@
       <label xml:lang="de" text="Gruppierung" />
       <label xml:lang="en" text="Grouping" />
       <label xml:lang="it" text="Raggruppamento" />
+      <label xml:lang="x-mapping" text="coarResourceTypes32:RMP5-3GQ6" />
     </category>
     <category ID="report">
       <label xml:lang="x-hosts" text="standalone" />
       <label xml:lang="de" text="Report" />
-      <label xml:lang="x-mapping" text="marcgt:reporting diniPublType:report diniPublType2022:Report schemaOrg:Report" />
+      <label xml:lang="x-mapping" text="marcgt:reporting diniPublType:report diniPublType2022:Report schemaOrg:Report coarResourceTypes32:c_93fc" />
       <label xml:lang="en" text="Report" />
       <label xml:lang="it" text="Rapporto" />
       <category ID="research_results">
         <label xml:lang="x-hosts" text="standalone" />
-        <label xml:lang="x-mapping" text="marcgt:reporting diniPublType:report diniPublType2022:Report schemaOrg:Report" />
+        <label xml:lang="x-mapping" text="marcgt:reporting diniPublType:report diniPublType2022:Report schemaOrg:Report coarResourceTypes32:c_18ws" />
         <label xml:lang="en" text="Research Results" />
         <label xml:lang="de" text="Forschungsergebnisse" />
         <label xml:lang="it" text="Risultati della ricerca" />
       </category>
       <category ID="in_house">
         <label xml:lang="x-hosts" text="standalone" />
-        <label xml:lang="x-mapping" text="marcgt:reporting diniPublType:report diniPublType2022:Report schemaOrg:Report" />
+        <label xml:lang="x-mapping" text="marcgt:reporting diniPublType:report diniPublType2022:Report schemaOrg:Report coarResourceTypes32:c_93fc" />
         <label xml:lang="en" text="In house" />
         <label xml:lang="it" text="In-house pubblicazione" />
         <label xml:lang="de" text="Hausinterne Veröffentlichung" />
@@ -174,13 +176,13 @@
       <category ID="press_release">
         <label xml:lang="x-hosts" text="standalone" />
         <label xml:lang="it" text="Comunicato stampa" />
-        <label xml:lang="x-mapping" text="marcgt:reporting diniPublType:report diniPublType2022:Report schemaOrg:Report" />
+        <label xml:lang="x-mapping" text="marcgt:reporting diniPublType:report diniPublType2022:Report schemaOrg:Report coarResourceTypes32:c_93fc" />
         <label xml:lang="de" text="Presseerklärung" />
         <label xml:lang="en" text="Press release" />
       </category>
       <category ID="declaration">
         <label xml:lang="x-hosts" text="standalone" />
-        <label xml:lang="x-mapping" text="marcgt:reporting diniPublType:report diniPublType2022:Report schemaOrg:Report" />
+        <label xml:lang="x-mapping" text="marcgt:reporting diniPublType:report diniPublType2022:Report schemaOrg:Report coarResourceTypes32:c_93fc" />
         <label xml:lang="de" text="Fachliche Stellungnahme" />
         <label xml:lang="en" text="Professional declaration" />
         <label xml:lang="it" text="Parere di esperti" />
@@ -189,18 +191,18 @@
     <category ID="teaching_material">
       <label xml:lang="de" text="Lehrmaterial" />
       <label xml:lang="x-hosts" text="standalone lecture" />
-      <label xml:lang="x-mapping" text="marcgt:instruction diniPublType:CourseMaterial diniPublType2022:CourseMaterial schemaOrg:LearningResource" />
+      <label xml:lang="x-mapping" text="marcgt:instruction diniPublType:CourseMaterial diniPublType2022:CourseMaterial schemaOrg:LearningResource coarResourceTypes32:c_e059" />
       <label xml:lang="en" text="Teaching Resource" />
       <label xml:lang="it" text="Materiale didattico" />
       <category ID="lecture_resource">
         <label xml:lang="x-hosts" text="standalone lecture" />
-        <label xml:lang="x-mapping" text="marcgt:instruction diniPublType:CourseMaterial diniPublType2022:CourseMaterial schemaOrg:LearningResource" />
+        <label xml:lang="x-mapping" text="marcgt:instruction diniPublType:CourseMaterial diniPublType2022:CourseMaterial schemaOrg:LearningResource coarResourceTypes32:c_e059" />
         <label xml:lang="de" text="Vorlesungsmaterial" />
         <label xml:lang="en" text="Lecture Resource" />
         <label xml:lang="it" text="Resource Lecture" />
       </category>
       <category ID="course_resources">
-        <label xml:lang="x-mapping" text="marcgt:instruction diniPublType:CourseMaterial diniPublType2022:CourseMaterial schemaOrg:LearningResource" />
+        <label xml:lang="x-mapping" text="marcgt:instruction diniPublType:CourseMaterial diniPublType2022:CourseMaterial schemaOrg:LearningResource coarResourceTypes32:c_e059" />
         <label xml:lang="x-hosts" text="standalone lecture" />
         <label xml:lang="de" text="Kurs- und Seminarmaterial" />
         <label xml:lang="en" text="Course Resources" />
@@ -210,7 +212,7 @@
     <category ID="book">
       <label xml:lang="it" text="Libro" />
       <label xml:lang="de" text="Buch" />
-      <label xml:lang="x-mapping" text="marcgt:book diniPublType:book diniPublType2022:Book schemaOrg:Book" />
+      <label xml:lang="x-mapping" text="marcgt:book diniPublType:book diniPublType2022:Book schemaOrg:Book coarResourceTypes32:c_2f33" />
       <label xml:lang="x-hosts" text="series standalone" />
       <label xml:lang="en" text="Book" />
     </category>
@@ -219,24 +221,24 @@
       <label xml:lang="en" text="Journal" />
       <label xml:lang="de" text="Zeitschrift" />
       <label xml:lang="it" text="Rivista" />
-      <label xml:lang="x-mapping" text="marcgt:journal diniPublType:Periodical diniPublType2022:Periodical schemaOrg:Periodical" />
+      <label xml:lang="x-mapping" text="marcgt:journal diniPublType:Periodical diniPublType2022:Periodical schemaOrg:Periodical coarResourceTypes32:c_0640" />
       <category ID="issue">
         <label xml:lang="de" text="Zeitschriftenheft" />
         <label xml:lang="en" text="Journal Issue" />
         <label xml:lang="x-hosts" text="standalone journal series" />
-        <label xml:lang="x-mapping" text="marcgt:issue diniPublType:PeriodicalPart diniPublType2022:PeriodicalPart schemaOrg:PublicationIssue" />
+        <label xml:lang="x-mapping" text="marcgt:issue diniPublType:PeriodicalPart diniPublType2022:PeriodicalPart schemaOrg:PublicationIssue coarResourceTypes32:QX5C-AR31" />
       </category>
     </category>
     <category ID="newspaper">
       <label xml:lang="x-hosts" text="standalone" />
       <label xml:lang="it" text="Giornale" />
       <label xml:lang="en" text="Newspaper" />
-      <label xml:lang="x-mapping" text="marcgt:newspaper diniPublType:Periodical diniPublType2022:Periodical schemaOrg:Periodical" />
+      <label xml:lang="x-mapping" text="marcgt:newspaper diniPublType:Periodical diniPublType2022:Periodical schemaOrg:Periodical coarResourceTypes32:c_2fe3" />
       <label xml:lang="de" text="Zeitung" />
     </category>
     <category ID="series">
       <label xml:lang="x-hosts" text="standalone" />
-      <label xml:lang="x-mapping" text="marcgt:series diniPublType:other diniPublType2022:Other schemaOrg:BookSeries" />
+      <label xml:lang="x-mapping" text="marcgt:series diniPublType:other diniPublType2022:Other schemaOrg:BookSeries coarResourceTypes32:QX5C-AR31?" />
       <label xml:lang="en" text="Series" />
       <label xml:lang="de" text="Serie" />
       <label xml:lang="it" text="Collana" />
@@ -244,14 +246,14 @@
     <category ID="blog">
       <label xml:lang="x-hosts" text="standalone" />
       <label xml:lang="de" text="Blog" />
-      <label xml:lang="x-mapping" text="marcgt:web_site diniPublType:Website diniPublType2022:DynamicWebRessource schemaOrg:Blog" />
+      <label xml:lang="x-mapping" text="marcgt:web_site diniPublType:Website diniPublType2022:DynamicWebRessource schemaOrg:Blog coarResourceTypes32:c_7ad9" />
       <label xml:lang="en" text="Blog" />
       <label xml:lang="it" text="Blog" />
     </category>
     <category ID="interview">
       <label xml:lang="it" text="Intervista" />
       <label xml:lang="x-hosts" text="journal newspaper standalone" />
-      <label xml:lang="x-mapping" text="marcgt:interview diniPublType:report diniPublType2022:Report schemaOrg:Report" />
+      <label xml:lang="x-mapping" text="marcgt:interview diniPublType:report diniPublType2022:Report schemaOrg:Report coarResourceTypes32:c_1843" />
       <label xml:lang="en" text="Interview" />
       <label xml:lang="de" text="Interview" />
     </category>
@@ -259,11 +261,11 @@
       <label xml:lang="x-hosts" text="standalone" />
       <label xml:lang="de" text="Forschungsdaten" />
       <label xml:lang="en" text="Research Data" />
-      <label xml:lang="x-mapping" text="marcgt:database diniPublType:ResearchData diniPublType2022:ResearchData schemaOrg:Dataset" />
+      <label xml:lang="x-mapping" text="marcgt:database diniPublType:ResearchData diniPublType2022:ResearchData schemaOrg:Dataset coarResourceTypes32:c_ddb1" />
       <label xml:lang="it" text="Dati di ricerca" />
       <category ID="software">
         <label xml:lang="en" text="Software" />
-        <label xml:lang="x-mapping" text="marcgt:computer_program diniPublType:Software diniPublType2022:Software schemaOrg:SoftwareApplication" />
+        <label xml:lang="x-mapping" text="marcgt:computer_program diniPublType:Software diniPublType2022:Software schemaOrg:SoftwareApplication coarResourceTypes32:c_5ce6" />
         <label xml:lang="x-hosts" text="standalone" />
         <label xml:lang="de" text="Software" />
       </category>
@@ -271,12 +273,12 @@
     <category ID="patent">
       <label xml:lang="x-hosts" text="standalone" />
       <label xml:lang="it" text="Brevetto" />
-      <label xml:lang="x-mapping" text="marcgt:patent diniPublType:patent diniPublType2022:Patent schemaOrg:CreativeWork" />
+      <label xml:lang="x-mapping" text="marcgt:patent diniPublType:patent diniPublType2022:Patent schemaOrg:CreativeWork coarResourceTypes32:c_15cd" />
       <label xml:lang="de" text="Patent" />
       <label xml:lang="en" text="Patent" />
     </category>
     <category ID="poster">
-      <label xml:lang="x-mapping" text="marcgt:technical_drawing diniPublType:ResearchData diniPublType2022:ConferencePoster schemaOrg:PresentationDigitalDocument" />
+      <label xml:lang="x-mapping" text="marcgt:technical_drawing diniPublType:ResearchData diniPublType2022:ConferencePoster schemaOrg:PresentationDigitalDocument coarResourceTypes32:c_6670" />
       <label xml:lang="en" text="Poster" />
       <label xml:lang="it" text="Locandina" />
       <label xml:lang="de" text="Poster" />
@@ -285,7 +287,7 @@
     <category ID="audio">
       <label xml:lang="en" text="Audio file" />
       <label xml:lang="x-hosts" text="standalone lecture" />
-      <label xml:lang="x-mapping" text="marcgt:sound diniPublType:Sound diniPublType2022:Sound schemaOrg:MediaObject" />
+      <label xml:lang="x-mapping" text="marcgt:sound diniPublType:Sound diniPublType2022:Sound schemaOrg:MediaObject coarResourceTypes32:c_18cc" />
       <label xml:lang="de" text="Tondokument" />
       <label xml:lang="it" text="Registrazione audio" />
     </category>
@@ -294,18 +296,18 @@
       <label xml:lang="it" text="Film / Video" />
       <label xml:lang="de" text="Film / Video" />
       <label xml:lang="en" text="Movie / Video" />
-      <label xml:lang="x-mapping" text="marcgt:motion_picture diniPublType:MovingImage diniPublType2022:MovingImage schemaOrg:MediaObject" />
+      <label xml:lang="x-mapping" text="marcgt:motion_picture diniPublType:MovingImage diniPublType2022:MovingImage schemaOrg:MediaObject coarResourceTypes32:c_12ce" />
     </category>
     <category ID="picture">
       <label xml:lang="it" text="Immagine" />
       <label xml:lang="x-hosts" text="standalone lecture" />
-      <label xml:lang="x-mapping" text="marcgt:picture diniPublType:StillImage diniPublType2022:StillImage schemaOrg:MediaObject" />
+      <label xml:lang="x-mapping" text="marcgt:picture diniPublType:StillImage diniPublType2022:StillImage schemaOrg:MediaObject coarResourceTypes32:c_ecc8" />
       <label xml:lang="de" text="Bild" />
       <label xml:lang="en" text="Picture" />
     </category>
     <category ID="broadcasting">
       <label xml:lang="x-hosts" text="standalone" />
-      <label xml:lang="x-mapping" text="marcgt:videorecording diniPublType:report diniPublType2022:Report schemaOrg:MediaObject" />
+      <label xml:lang="x-mapping" text="marcgt:videorecording diniPublType:report diniPublType2022:Report schemaOrg:MediaObject coarResourceTypes32:c_1843" />
       <label xml:lang="it" text="Programma televisivo o radiofonico" />
       <label xml:lang="de" text="Sendung" />
       <label xml:lang="en" text="Broadcasting" />
@@ -314,7 +316,7 @@
       <label xml:lang="x-hosts" text="standalone" />
       <label xml:lang="de" text="Vorlesung" />
       <label xml:lang="en" text="Lecture" />
-      <label xml:lang="x-mapping" text="marcgt:series diniPublType:lecture diniPublType2022:Lecture schemaOrg:Course" />
+      <label xml:lang="x-mapping" text="marcgt:series diniPublType:lecture diniPublType2022:Lecture schemaOrg:Course coarResourceTypes32:c_8544" />
       <label xml:lang="it" text="Lezione" />
     </category>
   </categories>


### PR DESCRIPTION
**Note**:
I've tried to be more precise with the mapping, I'm having some trouble with the literary types.
There are basically three rather generic types that could basically be used as fallbacks:

- [other periodical](http://purl.org/coar/resource_type/QX5C-AR31)
- [text](http://purl.org/coar/resource_type/c_18cf/)
- [other](http://purl.org/coar/resource_type/c_1843/)

Perhaps it makes sense to use other rather than an imprecise mapping.